### PR TITLE
Add SizesWindow

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		65DA48EA620F145052085D659AD90A0F /* Pods-Sizes_Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = DB98984468ED0D329A041618AC4171E0 /* Pods-Sizes_Tests-dummy.m */; };
 		6D89C3D6F986C88841D6F151539DA93F /* Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD638D16E22056FCB9DE8402366DB4EC /* Layout.swift */; };
 		725297DC00C531B210CE257EE909DA4D /* Pods-Sizes_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 5CBB0A69C4D39E9FC1C812CE97F6CC02 /* Pods-Sizes_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		792FE25821737DFB0015447A /* SizesWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 792FE25621737D940015447A /* SizesWindow.swift */; };
 		915A0EE7A07D592B34C9AD71EB250047 /* SizesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3631A0DE209DCB7A19112A1200B4DB11 /* SizesViewController.swift */; };
 		98F94F76C92B051C0D619E784FFEE4F3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A16F4CFC63FAC439D7A04994F579A03 /* Foundation.framework */; };
 		A2FC501168CFA6AE98AE0A89D18EB3D7 /* LayoutFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D20FEA4081925DFC68F46DFD6F844FE /* LayoutFactory.swift */; };
@@ -76,6 +77,7 @@
 		6AEB1C101487CB9765A164A480496EAC /* Pods-Sizes_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Sizes_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		6BA766608A9745B527FAEA3662535398 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		78F97FE2BC434610DABF7D647178FC50 /* Device.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Device.swift; sourceTree = "<group>"; };
+		792FE25621737D940015447A /* SizesWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizesWindow.swift; sourceTree = "<group>"; };
 		79E225EC17A90998BF8D2E5C46554427 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7CDB5F76365A479F784DE3BF96E24521 /* Sizes-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Sizes-umbrella.h"; sourceTree = "<group>"; };
 		7CF5109BC79CC15EFD1A067DC91AB8D4 /* Pods_Sizes_Tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Sizes_Tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -313,6 +315,7 @@
 				FB0996D7216A9CE300F22D06 /* Button.swift */,
 				FB0996DA216A9CE300F22D06 /* Colors.swift */,
 				FB0996D8216A9CE300F22D06 /* Designable.swift */,
+				792FE25621737D940015447A /* SizesWindow.swift */,
 			);
 			name = UI;
 			path = Sizes/Classes/UI;
@@ -513,6 +516,7 @@
 				60C994BB75D6C94F4F35E16D5D1F0597 /* Orientation.swift in Sources */,
 				FB230DE921693FEF00CC1D82 /* UIApplication + Orientations.swift in Sources */,
 				BC92F423BB9C5472B912F15C4EFD9E0F /* Sizes-dummy.m in Sources */,
+				792FE25821737DFB0015447A /* SizesWindow.swift in Sources */,
 				915A0EE7A07D592B34C9AD71EB250047 /* SizesViewController.swift in Sources */,
 				FB0996DB216A9CE300F22D06 /* Button.swift in Sources */,
 			);

--- a/Example/Sizes/AppDelegate.swift
+++ b/Example/Sizes/AppDelegate.swift
@@ -27,8 +27,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         tabBarController.setViewControllers([navigation, readme], animated: false)
         
         window.rootViewController = tabBarController
-        //        root.set(devices: Device.valuesForIdiom(.pad))
+        
         if CommandLine.arguments.contains("-uitest"), let sizesVC = window.sizesViewController {
+            //        sizesVC.set(devices: Device.valuesForIdiom(.pad))
             sizesVC.presentConfiguration()
         }
         window.makeKeyAndVisible()

--- a/Example/Sizes/AppDelegate.swift
+++ b/Example/Sizes/AppDelegate.swift
@@ -12,11 +12,10 @@ import Sizes
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
     
-    let window = UIWindow()
+    let window = SizesWindow()
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
-        let root = SizesViewController()
         let tabBarController = UITabBarController()
         let navigation = UINavigationController(rootViewController: ViewController())
         if #available(iOS 11.0, *) {
@@ -27,11 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         readme.tabBarItem = UITabBarItem(title: "Readme", image: UIImage(named: "github"), tag: 1)
         tabBarController.setViewControllers([navigation, readme], animated: false)
         
-        window.rootViewController = root
-        root.contain(viewController: tabBarController)
+        window.rootViewController = tabBarController
         //        root.set(devices: Device.valuesForIdiom(.pad))
-        if CommandLine.arguments.contains("-uitest") {
-            root.presentConfiguration()
+        if CommandLine.arguments.contains("-uitest"), let sizesVC = window.sizesViewController {
+            sizesVC.presentConfiguration()
         }
         window.makeKeyAndVisible()
         

--- a/Example/Sizes/AppDelegate.swift
+++ b/Example/Sizes/AppDelegate.swift
@@ -28,9 +28,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         window.rootViewController = tabBarController
         
-        if CommandLine.arguments.contains("-uitest"), let sizesVC = window.sizesViewController {
-            //        sizesVC.set(devices: Device.valuesForIdiom(.pad))
-            sizesVC.presentConfiguration()
+        if CommandLine.arguments.contains("-uitest") {
+//            window.sizesViewController.set(devices: Device.valuesForIdiom(.pad))
+            window.sizesViewController.presentConfiguration()
         }
         window.makeKeyAndVisible()
         

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -25,7 +25,7 @@ class Tests: XCTestCase {
         XCTAssertNotNil(window.sizesViewController)
         XCTAssertNotNil(window.containedRootViewController)
         
-        guard type(of: window.rootViewController!) == UIViewController.self else {
+        guard type(of: window.rootViewController!) == SizesViewController.self else {
             XCTFail()
             return
         }

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -6,10 +6,33 @@ class Tests: XCTestCase {
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
+        continueAfterFailure = false
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testSizesWindow() {
+        let window = SizesWindow()
+        
+        XCTAssertNil(window.rootViewController)
+        
+        window.rootViewController = UIViewController()
+        
+        XCTAssertNotNil(window.rootViewController)
+        XCTAssertNotNil(window.sizesViewController)
+        XCTAssertNotNil(window.containedRootViewController)
+        
+        guard type(of: window.rootViewController!) == UIViewController.self else {
+            XCTFail()
+            return
+        }
+        
+        guard type(of: window.containedRootViewController!) == UIViewController.self else {
+            XCTFail()
+            return
+        }
     }
 }

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -22,15 +22,8 @@ class Tests: XCTestCase {
         window.rootViewController = UIViewController()
         
         XCTAssertNotNil(window.rootViewController)
-        XCTAssertNotNil(window.sizesViewController)
-        XCTAssertNotNil(window.containedRootViewController)
         
-        guard type(of: window.rootViewController!) == SizesViewController.self else {
-            XCTFail()
-            return
-        }
-        
-        guard type(of: window.containedRootViewController!) == UIViewController.self else {
+        guard type(of: window.rootViewController!) == UIViewController.self else {
             XCTFail()
             return
         }

--- a/Sizes.podspec
+++ b/Sizes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Sizes'
-  s.version          = '0.2.1'
+  s.version          = '0.3.0'
   s.summary          = 'View your app on different device and font sizes.'
 
   s.description      = <<-DESC

--- a/Sizes.podspec
+++ b/Sizes.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Sizes'
-  s.version          = '0.3.0'
+  s.version          = '0.2.1'
   s.summary          = 'View your app on different device and font sizes.'
 
   s.description      = <<-DESC

--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -13,14 +13,11 @@ open class SizesWindow: UIWindow {
     private(set) open var sizesViewController: SizesViewController?
     
     override open var rootViewController: UIViewController? {
-        get {
-            return containedRootViewController
-        }
-        set {
-            if let rootVC = newValue, !rootVC.isKind(of: SizesViewController.self) {
+        didSet {
+            if let rootVC = rootViewController, !rootVC.isKind(of: SizesViewController.self) {
                 let root = SizesViewController()
                 sizesViewController = root
-                self.rootViewController = root
+                rootViewController = root
                 containedRootViewController = rootVC
                 root.contain(viewController: rootVC)
             }

--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -9,18 +9,18 @@ import UIKit
 
 open class SizesWindow: UIWindow {
     
-    private(set) open var containedRootViewController: UIViewController?
-    private(set) open var sizesViewController: SizesViewController?
+    public let sizesViewController = SizesViewController()
     
     override open var rootViewController: UIViewController? {
-        didSet {
-            if let rootVC = rootViewController, !rootVC.isKind(of: SizesViewController.self) {
-                let root = SizesViewController()
-                sizesViewController = root
-                rootViewController = root
-                containedRootViewController = rootVC
-                root.contain(viewController: rootVC)
+        get {
+            return sizesViewController.containedController
+        }
+        set {
+            guard let root = newValue, !root.isKind(of: SizesViewController.self) else {
+                return
             }
+            super.rootViewController = sizesViewController
+            sizesViewController.contain(viewController: root)
         }
     }
 }

--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -1,0 +1,29 @@
+//
+//  SizesWindow.swift
+//  Pods-Sizes_Example
+//
+//  Created by Bahadir Oncel on 14.10.2018.
+//
+
+import UIKit
+
+open class SizesWindow: UIWindow {
+    
+    private(set) open var containedRootViewController: UIViewController?
+    private(set) open var sizesViewController: SizesViewController?
+    
+    override open var rootViewController: UIViewController? {
+        get {
+            return containedRootViewController
+        }
+        set {
+            if let rootVC = newValue, !rootVC.isKind(of: SizesViewController.self) {
+                let root = SizesViewController()
+                sizesViewController = root
+                self.rootViewController = root
+                containedRootViewController = rootVC
+                root.contain(viewController: rootVC)
+            }
+        }
+    }
+}


### PR DESCRIPTION
I've tried overriding `get` and `set` for `rootViewController` property but it breaks UIKit, I get the error:
> Applications are expected to have a root view controller at the end of application launch
Although I can correctly retrieve the `rootViewController`. I believe overriding `set` breaks UIKit. You can see the said approach in commit `8feaa4a`
And overriding `get` without overriding `set` does not seem possible.

I've also bumped up the version to 0.3 and configured `AppDelegate` to use the new `SizesWindow` approach. All tests pass.