### PR TITLE
Resize UIWindow approach to allow presenting view controllers

### DIFF
--- a/Example/Sizes.xcodeproj/project.pbxproj
+++ b/Example/Sizes.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		607FACE01AFB9204008FA782 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 607FACDE1AFB9204008FA782 /* LaunchScreen.xib */; };
 		607FACEC1AFB9204008FA782 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* Tests.swift */; };
 		C98A470F60561190B231D996 /* Pods_Sizes_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 32CD9ED3AD462901E10F812A /* Pods_Sizes_Tests.framework */; };
+		FB03B9A22178C2D300A889FC /* PresentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB03B9A12178C2D300A889FC /* PresentViewController.swift */; };
 		FB230DF4216947EA00CC1D82 /* Sizes_ExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB230DF3216947EA00CC1D82 /* Sizes_ExampleUITests.swift */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,7 @@
 		9B77CFB1D7DC9172C875F99F /* Pods-Sizes_Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sizes_Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Sizes_Tests/Pods-Sizes_Tests.release.xcconfig"; sourceTree = "<group>"; };
 		BAA35FF65E8C54C57D8170D3 /* Sizes.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Sizes.podspec; path = ../Sizes.podspec; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		C03D3993D1015065CD903D53 /* Pods-Sizes_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Sizes_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Sizes_Example/Pods-Sizes_Example.debug.xcconfig"; sourceTree = "<group>"; };
+		FB03B9A12178C2D300A889FC /* PresentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresentViewController.swift; sourceTree = "<group>"; };
 		FB230DF1216947EA00CC1D82 /* Sizes_ExampleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Sizes_ExampleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB230DF3216947EA00CC1D82 /* Sizes_ExampleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sizes_ExampleUITests.swift; sourceTree = "<group>"; };
 		FB230DF5216947EA00CC1D82 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 			children = (
 				607FACD51AFB9204008FA782 /* AppDelegate.swift */,
 				607FACD71AFB9204008FA782 /* ViewController.swift */,
+				FB03B9A12178C2D300A889FC /* PresentViewController.swift */,
 				607FACD91AFB9204008FA782 /* Main.storyboard */,
 				607FACDC1AFB9204008FA782 /* Images.xcassets */,
 				607FACDE1AFB9204008FA782 /* LaunchScreen.xib */,
@@ -388,6 +391,7 @@
 			files = (
 				607FACD81AFB9204008FA782 /* ViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,
+				FB03B9A22178C2D300A889FC /* PresentViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Sizes/AppDelegate.swift
+++ b/Example/Sizes/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             window?.makeKeyAndVisible()
             /// Automatically present the Sizes configuration sheet if we're running UITests.
             if CommandLine.arguments.contains("-uitest") {
-//                (window as! SizesWindow).sizesViewController.presentConfiguration()
+                (window as! SizesWindow).presentConfiguration()
             }
         #endif
         

--- a/Example/Sizes/AppDelegate.swift
+++ b/Example/Sizes/AppDelegate.swift
@@ -23,7 +23,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             window?.makeKeyAndVisible()
             /// Automatically present the Sizes configuration sheet if we're running UITests.
             if CommandLine.arguments.contains("-uitest") {
-                (window as! SizesWindow).sizesViewController.presentConfiguration()
+//                (window as! SizesWindow).sizesViewController.presentConfiguration()
             }
         #endif
         

--- a/Example/Sizes/Base.lproj/Main.storyboard
+++ b/Example/Sizes/Base.lproj/Main.storyboard
@@ -34,7 +34,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Icq-wu-H3o">
-                                                <rect key="frame" x="20" y="48.5" width="313" height="103.5"/>
+                                                <rect key="frame" x="20" y="48.5" width="313" height="143.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="📱 Resize your app to multiple devices" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kVX-Km-Gtd">
                                                         <rect key="frame" x="0.0" y="0.0" width="313" height="20.5"/>
@@ -54,6 +54,13 @@
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
+                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4My-PX-Q7X">
+                                                        <rect key="frame" x="0.0" y="113.5" width="313" height="30"/>
+                                                        <state key="normal" title="Present"/>
+                                                        <connections>
+                                                            <action selector="presentTapped:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="c9g-Ap-HHt"/>
+                                                        </connections>
+                                                    </button>
                                                 </subviews>
                                             </stackView>
                                         </subviews>
@@ -100,6 +107,7 @@
                 <tabBarController automaticallyAdjustsScrollViewInsets="NO" id="tZA-0f-EzA" sceneMemberID="viewController">
                     <toolbarItems/>
                     <tabBar key="tabBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Qun-ei-Dek">
+                        <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     </tabBar>

--- a/Example/Sizes/Base.lproj/Main.storyboard
+++ b/Example/Sizes/Base.lproj/Main.storyboard
@@ -34,31 +34,42 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" axis="vertical" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Icq-wu-H3o">
-                                                <rect key="frame" x="20" y="48.5" width="313" height="143.5"/>
+                                                <rect key="frame" x="20" y="48.5" width="313" height="177"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="📱 Resize your app to multiple devices" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kVX-Km-Gtd">
-                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="313" height="25.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="📐 View different orientations" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Riw-Tc-7Er">
-                                                        <rect key="frame" x="0.0" y="30.5" width="313" height="20.5"/>
+                                                        <rect key="frame" x="0.0" y="35.5" width="313" height="25"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="🔠 Display different font sizes, including accessibility ones" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KWK-qj-XdB">
-                                                        <rect key="frame" x="0.0" y="61" width="313" height="42.5"/>
+                                                        <rect key="frame" x="0.0" y="70.5" width="313" height="52.5"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
-                                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4My-PX-Q7X">
-                                                        <rect key="frame" x="0.0" y="113.5" width="313" height="30"/>
-                                                        <state key="normal" title="Present"/>
+                                                    <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4My-PX-Q7X">
+                                                        <rect key="frame" x="0.0" y="133" width="313" height="44"/>
+                                                        <color key="backgroundColor" red="0.56422978639999999" green="0.077530883250000002" blue="0.99607580900000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="44" id="K4c-IM-LIv"/>
+                                                        </constraints>
+                                                        <state key="normal" title="Present">
+                                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </state>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="4"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
                                                         <connections>
-                                                            <action selector="presentTapped:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="c9g-Ap-HHt"/>
+                                                            <segue destination="NsV-hQ-RZM" kind="presentation" id="OSp-pJ-NPd"/>
                                                         </connections>
                                                     </button>
                                                 </subviews>
@@ -100,6 +111,50 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="x5A-6p-PRh" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="1809" y="27"/>
+        </scene>
+        <!--Present View Controller-->
+        <scene sceneID="XNV-rN-ZDD">
+            <objects>
+                <viewController id="NsV-hQ-RZM" customClass="PresentViewController" customModule="Sizes_Example" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="Wpf-Gn-i71"/>
+                        <viewControllerLayoutGuide type="bottom" id="VoV-wl-mcF"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="tqa-G5-F6b">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KmT-L3-SCd">
+                                <rect key="frame" x="47" y="311.5" width="281" height="44"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="44" id="5vS-QO-6O8"/>
+                                </constraints>
+                                <state key="normal" title="Dismiss">
+                                    <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="4"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="onDismiss:" destination="NsV-hQ-RZM" eventType="touchUpInside" id="Q9v-9c-uLd"/>
+                                    <action selector="presentTapped:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="Ukk-ov-egq"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="KmT-L3-SCd" firstAttribute="centerX" secondItem="tqa-G5-F6b" secondAttribute="centerX" id="93O-9Z-cg3"/>
+                            <constraint firstItem="KmT-L3-SCd" firstAttribute="width" secondItem="tqa-G5-F6b" secondAttribute="width" multiplier="75%" id="ZH1-lv-jnz"/>
+                            <constraint firstItem="KmT-L3-SCd" firstAttribute="centerY" secondItem="tqa-G5-F6b" secondAttribute="centerY" id="m6W-Lv-TE3"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="OCD-Qi-823" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2540" y="27"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="yTX-Hn-vxH">

--- a/Example/Sizes/PresentViewController.swift
+++ b/Example/Sizes/PresentViewController.swift
@@ -10,21 +10,7 @@ import UIKit
 
 class PresentViewController: UIViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+    @IBAction func onDismiss(_ sender: UIButton) {
+        dismiss(animated: true)
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/Example/Sizes/PresentViewController.swift
+++ b/Example/Sizes/PresentViewController.swift
@@ -1,0 +1,30 @@
+//
+//  PresentViewController.swift
+//  Sizes_Example
+//
+//  Created by Marcos Griselli on 18/10/2018.
+//  Copyright © 2018 CocoaPods. All rights reserved.
+//
+
+import UIKit
+
+class PresentViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Example/Sizes/ViewController.swift
+++ b/Example/Sizes/ViewController.swift
@@ -8,17 +8,4 @@
 
 import UIKit
 
-class ViewController: UIViewController {
-    
-    @IBAction func presentTapped(_ sender: UIButton) {
-        let v = UIViewController()
-        v.view.backgroundColor = .red
-        DispatchQueue.main.async {
-            self.present(v, animated: true, completion: {
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: {
-                    v.dismiss(animated: true)
-                })
-            })
-        }
-    }
-}
+class ViewController: UIViewController {}

--- a/Example/Sizes/ViewController.swift
+++ b/Example/Sizes/ViewController.swift
@@ -8,4 +8,14 @@
 
 import UIKit
 
-class ViewController: UIViewController {}
+class ViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            let v = UIViewController()
+            v.view.backgroundColor = .red
+            self.present(v, animated: true)
+        }
+    }
+}

--- a/Example/Sizes/ViewController.swift
+++ b/Example/Sizes/ViewController.swift
@@ -10,12 +10,15 @@ import UIKit
 
 class ViewController: UIViewController {
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            let v = UIViewController()
-            v.view.backgroundColor = .red
-            self.present(v, animated: true)
+    @IBAction func presentTapped(_ sender: UIButton) {
+        let v = UIViewController()
+        v.view.backgroundColor = .red
+        DispatchQueue.main.async {
+            self.present(v, animated: true, completion: {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0, execute: {
+                    v.dismiss(animated: true)
+                })
+            })
         }
     }
 }

--- a/Sizes/Classes/UI/Button/Button.swift
+++ b/Sizes/Classes/UI/Button/Button.swift
@@ -19,6 +19,10 @@ internal class Button: UIButton {
         set(style: style)
     }
     
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         set(selected: isSelected)

--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -9,7 +9,14 @@ import UIKit
 
 open class SizesWindow: UIWindow {
     
+    /// SizesViewController that will update the contained view
     public let sizesViewController = SizesViewController()
+    
+    /// Window to display the configuration UI
+    private let configurationWindow: UIWindow
+    
+    /// Public API
+    open var shakeGestureEnabled: Bool = true
     
     override open var rootViewController: UIViewController? {
         get {
@@ -21,6 +28,43 @@ open class SizesWindow: UIWindow {
             }
             super.rootViewController = sizesViewController
             sizesViewController.contain(viewController: root)
+        }
+    }
+    
+    public init() {
+        let configurationController = ConfigurationViewController()
+        configurationWindow = UIWindow(frame: CGRect(x: 0, y: UIScreen.main.bounds.height, width: 375, height: 367))
+        configurationWindow.backgroundColor = .clear
+        configurationWindow.windowLevel = .alert
+        configurationWindow.rootViewController = configurationController
+        configurationWindow.makeKeyAndVisible()
+        
+        super.init(frame: UIScreen.main.bounds)
+        
+        configurationController.update = { [unowned self] orientation, device, textSize in
+            self.sizesViewController.debug(device: device, orientation: orientation, contentSize: textSize)
+        }
+    }
+    
+    required public init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Enable detection of shake motion
+    override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            if shakeGestureEnabled {
+                presentConfiguration()
+            }
+        }
+    }
+
+    /// Manually present the configuration view
+    private func presentConfiguration() {
+        DispatchQueue.main.async { [unowned self] in
+            UIView.animate(withDuration: 1, delay: 0, usingSpringWithDamping: 0.75, initialSpringVelocity: 0, options: .curveEaseOut, animations: {
+                self.configurationWindow.frame.origin.y = 300
+            }, completion: nil)
         }
     }
 }

--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -69,7 +69,7 @@ open class SizesWindow: UIWindow {
     }
 
     /// Manually present the configuration view
-    private func presentConfiguration() {
+    public func presentConfiguration() {
         let frame = configurationWindow.frame
         DispatchQueue.main.async { [unowned self] in
             UIView.animate(withDuration: 1, delay: 0, usingSpringWithDamping: 0.75, initialSpringVelocity: 0, options: .curveEaseOut, animations: {

--- a/Sizes/Classes/ViewControllers/ConfigurationViewController.swift
+++ b/Sizes/Classes/ViewControllers/ConfigurationViewController.swift
@@ -63,6 +63,16 @@ internal class ConfigurationViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        /// TODO: - Create UIStyle
+        view.layer.cornerRadius = 12.0
+        if #available(iOS 11.0, *) {
+            view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+        }
+        view.layer.shadowColor = UIColor.black.cgColor
+        view.layer.shadowOpacity = 0.15
+        view.layer.shadowRadius = 4
+        view.layer.shadowOffset = CGSize(width: 0, height: -2)
+
         /// Setup
         orientationSection.isHidden = !UIApplication.shared.supportsPortraitAndLandscape
         set(devices: supportedDevices)
@@ -71,7 +81,7 @@ internal class ConfigurationViewController: UIViewController {
         panGesture.delegate = self
 
         /// TODO: - Use a better approach.
-        view.transform = CGAffineTransform(translationX: 0, y: view.bounds.height)
+//        view.transform = CGAffineTransform(translationX: 0, y: view.bounds.height)
     }
     
     /// Set the available devices on screen

--- a/Sizes/Classes/ViewControllers/ConfigurationViewController.swift
+++ b/Sizes/Classes/ViewControllers/ConfigurationViewController.swift
@@ -52,6 +52,14 @@ internal class ConfigurationViewController: UIViewController {
     /// Update layout closure
     var update: ((Orientation, Device, UIContentSizeCategory) -> Void)?
     
+    open override var shouldAutorotate: Bool {
+        return true
+    }
+    
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.all
+    }
+    
     init() {
         super.init(nibName: String(describing: ConfigurationViewController.self),
                    bundle: Bundle(for: ConfigurationViewController.self))
@@ -76,12 +84,6 @@ internal class ConfigurationViewController: UIViewController {
         /// Setup
         orientationSection.isHidden = !UIApplication.shared.supportsPortraitAndLandscape
         set(devices: supportedDevices)
-        
-        panGesture.cancelsTouchesInView = false
-        panGesture.delegate = self
-
-        /// TODO: - Use a better approach.
-//        view.transform = CGAffineTransform(translationX: 0, y: view.bounds.height)
     }
     
     /// Set the available devices on screen
@@ -127,39 +129,5 @@ internal class ConfigurationViewController: UIViewController {
             .compactMap { $0 as? Button }
             .forEach { $0.set(style: .normal) }
         button.set(style: .selected)
-    }
-
-    @IBAction func dragged(_ sender: UIPanGestureRecognizer) {
-        let translation = sender.translation(in: view)
-        switch sender.state {
-        case .changed:
-            if translation.y > 0 {
-            view.transform = CGAffineTransform(translationX: 0, y: translation.y)
-            }
-        case .cancelled, .ended:
-            /// TODO: - Add rubber-banding + force release.
-            let percentageComplete = translation.y / view.bounds.height
-            let shouldDismiss = percentageComplete > 0.5
-            let yMovement = shouldDismiss ? view.bounds.height : 0
-            UIView.animate(withDuration: 0.3, animations: {
-                self.view.transform = CGAffineTransform(translationX: 0, y: yMovement)
-            }, completion: nil)
-        default: break
-        }
-    }
-}
-
-// MARK: - UIGestureRecognizerDelegate
-extension ConfigurationViewController: UIGestureRecognizerDelegate {
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldReceive touch: UITouch) -> Bool {
-        guard let view = touch.view else {
-            return true
-        }
-        
-        return !view.isKind(of: UIButton.self)
-    }
-    
-    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
-        return false
     }
 }

--- a/Sizes/Classes/ViewControllers/ConfigurationViewController.xib
+++ b/Sizes/Classes/ViewControllers/ConfigurationViewController.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
+    <device id="retina5_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -15,18 +15,17 @@
                 <outlet property="deviceStackView" destination="aEc-gf-gXQ" id="xP7-e3-En6"/>
                 <outlet property="orientationSection" destination="A76-bg-D40" id="BM4-wa-ghF"/>
                 <outlet property="orientationStackView" destination="uJa-v2-INt" id="hb7-KF-CeE"/>
-                <outlet property="panGesture" destination="PCu-7a-RIN" id="8Jy-JD-rg7"/>
                 <outlet property="textSizeLabel" destination="F4i-JL-itu" id="2UN-Ov-AsW"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" misplaced="YES" id="i5M-Pr-FkT">
+        <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
             <rect key="frame" x="0.0" y="0.0" width="362" height="350"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3hU-0G-c4s">
-                    <rect key="frame" x="145" y="10" width="72" height="4"/>
+                    <rect key="frame" x="144.66666666666666" y="10" width="72.666666666666657" height="4"/>
                     <color key="backgroundColor" white="0.91232638889999995" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="4" id="usY-9z-Aac"/>
@@ -38,26 +37,26 @@
                     </userDefinedRuntimeAttributes>
                 </view>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" alignment="top" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="Xcj-rh-6et">
-                    <rect key="frame" x="0.0" y="35" width="362" height="380"/>
+                    <rect key="frame" x="0.0" y="44" width="362" height="287"/>
                     <subviews>
                         <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="A76-bg-D40" userLabel="Orientation Section">
-                            <rect key="frame" x="0.0" y="0.0" width="206" height="105"/>
+                            <rect key="frame" x="0.0" y="0.0" width="206" height="59"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Orientation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kXC-Lh-CvB">
-                                    <rect key="frame" x="20" y="0.0" width="90" height="20.5"/>
+                                    <rect key="frame" x="20" y="0.0" width="90" height="20.333333333333332"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <color key="textColor" red="0.29019607843137252" green="0.29019607843137252" blue="0.29019607843137252" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="uJa-v2-INt">
-                                    <rect key="frame" x="20" y="30.5" width="179" height="72.5"/>
+                                    <rect key="frame" x="20" y="30.333333333333329" width="179" height="44"/>
                                     <subviews>
                                         <button opaque="NO" contentMode="scaleToFill" selected="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="QmS-CO-Gn9" customClass="Button" customModule="Sizes" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="14.5" width="70" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="70" height="44"/>
                                             <color key="backgroundColor" red="0.56422978639999999" green="0.077530883250000002" blue="0.99607580900000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <accessibility key="accessibilityConfiguration" identifier="portrait"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="44" id="bmh-zP-cOT"/>
+                                                <constraint firstAttribute="height" constant="44" id="NCR-Ri-ckn"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                             <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
@@ -69,7 +68,7 @@
                                             </connections>
                                         </button>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SNA-TH-lPQ" customClass="Button" customModule="Sizes" customModuleProvider="target">
-                                            <rect key="frame" x="80" y="14.5" width="99" height="44"/>
+                                            <rect key="frame" x="80" y="0.0" width="99" height="44"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <accessibility key="accessibilityConfiguration" identifier="landscape"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
@@ -83,6 +82,7 @@
                                         </button>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstAttribute="height" constant="44" id="2m0-4S-ZYc"/>
                                         <constraint firstItem="SNA-TH-lPQ" firstAttribute="height" secondItem="QmS-CO-Gn9" secondAttribute="height" id="JU9-Tb-mk3"/>
                                     </constraints>
                                     <userDefinedRuntimeAttributes>
@@ -93,25 +93,24 @@
                                 </stackView>
                             </subviews>
                             <constraints>
+                                <constraint firstItem="uJa-v2-INt" firstAttribute="top" secondItem="kXC-Lh-CvB" secondAttribute="bottom" constant="10" id="4cE-gL-L6U"/>
                                 <constraint firstAttribute="trailing" secondItem="uJa-v2-INt" secondAttribute="trailing" constant="7" id="5pR-z6-uVq"/>
                                 <constraint firstItem="uJa-v2-INt" firstAttribute="leading" secondItem="kXC-Lh-CvB" secondAttribute="leading" id="HkH-Ta-9on"/>
-                                <constraint firstItem="kXC-Lh-CvB" firstAttribute="top" secondItem="A76-bg-D40" secondAttribute="top" id="SlH-KC-Csm"/>
-                                <constraint firstItem="uJa-v2-INt" firstAttribute="top" secondItem="kXC-Lh-CvB" secondAttribute="bottom" constant="10" id="WvU-Up-jKX"/>
+                                <constraint firstItem="kXC-Lh-CvB" firstAttribute="top" secondItem="A76-bg-D40" secondAttribute="top" id="NHc-FY-uI6"/>
                                 <constraint firstItem="kXC-Lh-CvB" firstAttribute="leading" secondItem="A76-bg-D40" secondAttribute="leading" constant="20" id="XOP-Bv-RC8"/>
-                                <constraint firstAttribute="bottom" secondItem="uJa-v2-INt" secondAttribute="bottom" constant="2" id="u7m-1f-QRL"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="0ir-Q5-VNn" userLabel="Device Section">
-                            <rect key="frame" x="0.0" y="120" width="362" height="165"/>
+                            <rect key="frame" x="0.0" y="74" width="362" height="99.333333333333314"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Device" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5qx-Uh-bzH">
-                                    <rect key="frame" x="20" y="0.0" width="54.5" height="101"/>
+                                    <rect key="frame" x="20.000000000000004" y="0.0" width="54.333333333333343" height="20.333333333333332"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JHU-YI-cEA">
-                                    <rect key="frame" x="0.0" y="111" width="362" height="44"/>
+                                    <rect key="frame" x="0.0" y="30.333333333333343" width="362" height="44"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="aEc-gf-gXQ">
                                             <rect key="frame" x="20" y="0.0" width="840" height="44"/>
@@ -213,6 +212,9 @@
                                                     </connections>
                                                 </button>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="44" id="bOB-Xf-4jY"/>
+                                            </constraints>
                                             <userDefinedRuntimeAttributes>
                                                 <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
                                                     <real key="value" value="0.0"/>
@@ -222,7 +224,6 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="aEc-gf-gXQ" firstAttribute="height" secondItem="JHU-YI-cEA" secondAttribute="height" id="3mW-0q-dkd"/>
-                                        <constraint firstAttribute="height" constant="44" id="5qx-9W-gnk"/>
                                         <constraint firstAttribute="trailing" secondItem="aEc-gf-gXQ" secondAttribute="trailing" constant="20" id="ElF-tg-Bpo"/>
                                         <constraint firstAttribute="bottom" secondItem="aEc-gf-gXQ" secondAttribute="bottom" id="geL-zk-Rfc"/>
                                         <constraint firstItem="aEc-gf-gXQ" firstAttribute="leading" secondItem="JHU-YI-cEA" secondAttribute="leading" constant="20" id="mqc-1w-lHD"/>
@@ -232,34 +233,33 @@
                             </subviews>
                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstItem="JHU-YI-cEA" firstAttribute="top" secondItem="5qx-Uh-bzH" secondAttribute="bottom" constant="10" id="2aA-DO-gXA"/>
                                 <constraint firstItem="5qx-Uh-bzH" firstAttribute="leading" secondItem="0ir-Q5-VNn" secondAttribute="leading" constant="20" id="7qo-f5-00z"/>
-                                <constraint firstAttribute="bottom" secondItem="JHU-YI-cEA" secondAttribute="bottom" constant="10" id="EhZ-RI-ZdX"/>
-                                <constraint firstItem="5qx-Uh-bzH" firstAttribute="top" secondItem="0ir-Q5-VNn" secondAttribute="top" id="FgT-v9-WB8"/>
+                                <constraint firstItem="5qx-Uh-bzH" firstAttribute="top" secondItem="0ir-Q5-VNn" secondAttribute="top" id="87V-JS-vXi"/>
                                 <constraint firstItem="JHU-YI-cEA" firstAttribute="leading" secondItem="0ir-Q5-VNn" secondAttribute="leading" id="iQN-Ui-k7E"/>
                                 <constraint firstAttribute="trailing" secondItem="JHU-YI-cEA" secondAttribute="trailing" id="iqU-tp-U4d"/>
+                                <constraint firstItem="JHU-YI-cEA" firstAttribute="top" secondItem="5qx-Uh-bzH" secondAttribute="bottom" constant="10" id="m7V-uz-arT"/>
                             </constraints>
                         </view>
                         <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="zcD-oz-Pcf" userLabel="Text Section">
-                            <rect key="frame" x="0.0" y="300" width="362" height="80"/>
+                            <rect key="frame" x="0.0" y="188.33333333333334" width="362" height="98.666666666666657"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nSk-z6-CKZ">
-                                    <rect key="frame" x="20" y="0.0" width="34" height="20.5"/>
+                                    <rect key="frame" x="20" y="0.0" width="34" height="20.333333333333332"/>
                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="17"/>
                                     <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="UjZ-h6-Z3Y">
-                                    <rect key="frame" x="20" y="30.5" width="322" height="42"/>
+                                    <rect key="frame" x="20" y="30.333333333333343" width="322" height="42"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="A" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fjq-na-kkb">
-                                            <rect key="frame" x="0.0" y="12" width="10.5" height="18"/>
+                                            <rect key="frame" x="0.0" y="12" width="10.666666666666666" height="18"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="15"/>
                                             <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <slider opaque="NO" contentMode="scaleToFill" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="3" minValue="0.0" maxValue="9" translatesAutoresizingMaskIntoConstraints="NO" id="NHE-nA-MqD">
-                                            <rect key="frame" x="18.5" y="6" width="275.5" height="31"/>
+                                            <rect key="frame" x="18.666666666666657" y="6" width="271.33333333333337" height="31"/>
                                             <color key="tintColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                             <accessibility key="accessibilityConfiguration" identifier="fontSlider"/>
                                             <connections>
@@ -267,7 +267,7 @@
                                             </connections>
                                         </slider>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" text="A" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TIj-bO-GYe">
-                                            <rect key="frame" x="302" y="0.0" width="20" height="42"/>
+                                            <rect key="frame" x="298" y="0.0" width="24" height="42"/>
                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="35"/>
                                             <color key="textColor" red="0.2901960784" green="0.2901960784" blue="0.2901960784" alpha="1" colorSpace="calibratedRGB"/>
                                             <nil key="highlightedColor"/>
@@ -280,7 +280,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </stackView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="UICTContentSizeCategoryL" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="F4i-JL-itu">
-                                    <rect key="frame" x="62" y="1.5" width="188.5" height="18"/>
+                                    <rect key="frame" x="61.999999999999986" y="1" width="188.66666666666663" height="18"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                     <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
@@ -294,7 +294,6 @@
                                 <constraint firstAttribute="trailing" secondItem="UjZ-h6-Z3Y" secondAttribute="trailing" constant="20" id="XC2-76-Jd8"/>
                                 <constraint firstItem="F4i-JL-itu" firstAttribute="leading" secondItem="nSk-z6-CKZ" secondAttribute="trailing" constant="8" id="XrQ-ng-0ue"/>
                                 <constraint firstItem="UjZ-h6-Z3Y" firstAttribute="top" secondItem="nSk-z6-CKZ" secondAttribute="bottom" constant="10" id="fy5-m3-VIc"/>
-                                <constraint firstAttribute="height" constant="80" id="uaj-ZY-qzt"/>
                                 <constraint firstItem="UjZ-h6-Z3Y" firstAttribute="leading" secondItem="nSk-z6-CKZ" secondAttribute="leading" id="ub9-i1-3nP"/>
                             </constraints>
                         </view>
@@ -305,28 +304,20 @@
                     </constraints>
                 </stackView>
             </subviews>
-            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <gestureRecognizers/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Xcj-rh-6et" secondAttribute="bottom" constant="10" id="51N-V5-HRB"/>
+                <constraint firstItem="Xcj-rh-6et" firstAttribute="bottom" secondItem="fnl-2z-Ty3" secondAttribute="bottom" constant="15" id="7k1-WX-brj"/>
+                <constraint firstItem="Xcj-rh-6et" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="topMargin" id="B1Q-Qh-bHN"/>
                 <constraint firstItem="3hU-0G-c4s" firstAttribute="width" secondItem="i5M-Pr-FkT" secondAttribute="width" multiplier="20%" id="J1o-cm-UZZ"/>
                 <constraint firstItem="Xcj-rh-6et" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="J8V-k8-6gd"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Xcj-rh-6et" secondAttribute="trailing" id="Mxc-MG-JIU"/>
-                <constraint firstItem="3hU-0G-c4s" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="10" id="N6K-8f-SAF"/>
+                <constraint firstItem="3hU-0G-c4s" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" constant="10" id="N6K-8f-SAF"/>
                 <constraint firstItem="3hU-0G-c4s" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="Xrl-Cg-UBb"/>
-                <constraint firstItem="Xcj-rh-6et" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="35" id="ddL-Wq-IlZ"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
-            <connections>
-                <outletCollection property="gestureRecognizers" destination="PCu-7a-RIN" appends="YES" id="qDB-tY-iY6"/>
-            </connections>
             <point key="canvasLocation" x="27.199999999999999" y="245.12743628185908"/>
         </view>
-        <panGestureRecognizer minimumNumberOfTouches="1" id="PCu-7a-RIN">
-            <connections>
-                <action selector="dragged:" destination="-1" id="ahc-1O-4DX"/>
-            </connections>
-        </panGestureRecognizer>
     </objects>
 </document>

--- a/Sizes/Classes/ViewControllers/SizesViewController.swift
+++ b/Sizes/Classes/ViewControllers/SizesViewController.swift
@@ -28,57 +28,6 @@ open class SizesViewController: UIViewController {
     
     /// Scales the contained view when the device to layout is larger than the device than is currently running Sizes
     public var scalesViewIfNecessary: Bool = true
-
-    /// Defines if the configuration view should present on shake
-    public var shakeGestureEnabled: Bool = true
-    
-    open override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = UIColor(white: 0.88, alpha: 1.0)
-        
-        addChild(configurationController)
-        let configView = configurationController.view!
-        configView.translatesAutoresizingMaskIntoConstraints = false
-        
-        /// TODO: - Create UIStyle
-        configView.layer.cornerRadius = 12.0
-        if #available(iOS 11.0, *) {
-            configView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
-        }
-        configView.layer.shadowColor = UIColor.black.cgColor
-        configView.layer.shadowOpacity = 0.15
-        configView.layer.shadowRadius = 4
-        configView.layer.shadowOffset = CGSize(width: 0, height: -2)
-        view.addSubview(configView)
-        
-        NSLayoutConstraint.activate([
-            configView.leftAnchor.constraint(equalTo: view.leftAnchor),
-            configView.rightAnchor.constraint(equalTo: view.rightAnchor),
-            configView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-            ])
-        configurationController.didMove(toParent: self)
-        configurationController.update = { [unowned self] orientation, device, textSize in
-            self.debug(device: device, orientation: orientation, contentSize: textSize)
-        }
-    }
-    
-    /// Enable detection of shake motion
-    override open func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
-        if motion == .motionShake {
-            if shakeGestureEnabled {
-                presentConfiguration()
-            }
-        }
-    }
-    
-    /// Manually present the configuration UI
-    public func presentConfiguration() {
-        DispatchQueue.main.async { [unowned self] in
-            UIView.animate(withDuration: 1, delay: 0, usingSpringWithDamping: 0.75, initialSpringVelocity: 0, options: .curveEaseOut, animations: {
-                self.configurationController.view.transform = .identity
-            }, completion: nil)
-        }
-    }
     
     /// Performs layout for selected device, orientation and content size.
     ///
@@ -89,7 +38,8 @@ open class SizesViewController: UIViewController {
     internal func debug(device: Device,
                         orientation: Orientation,
                         contentSize: UIContentSizeCategory) {
-        guard let containedViewController = containedController else {
+        guard let containedViewController = containedController, let sizesWindow = UIApplication.shared.windows.first(where:
+            { $0 is SizesWindow }) else {
             return
         }
         
@@ -100,18 +50,28 @@ open class SizesViewController: UIViewController {
         currentConstraints = containedView.constraintTo(size: layout.size)
         
         setOverrideTraitCollection(layout.traits, forChild: containedViewController)
-        containedViewController.view.setNeedsLayout()
-        containedViewController.view.layoutIfNeeded()
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        
+        sizesWindow.frame = CGRect(origin: CGPoint.zero, size: layout.size)
         
         if scalesViewIfNecessary {
             containedView.transform = .identity
-            let containedSize = containedView.bounds.size
-            let canvasSize = view.bounds.size
+            let containedSize = layout.size
+            let canvasSize = UIScreen.main.bounds.size
             if containedSize.exceeds(size: canvasSize) {
                 let scaledSize = containedSize.scaleToFit(size: canvasSize)
-                containedView.transform = CGAffineTransform(scaleX: scaledSize.width / containedSize.width, y: scaledSize.height / containedSize.height)
+                let scaleX = scaledSize.width / containedSize.width
+                let scaleY = scaledSize.height / containedSize.height
+                containedView.transform = CGAffineTransform(scaleX: scaleX, y: scaleY)
+                sizesWindow.frame.size = CGSize(width: sizesWindow.frame.size.width * scaleX, height: sizesWindow.frame.size.height * scaleY)
             }
         }
+
+        sizesWindow.center = CGPoint(x: UIScreen.main.bounds.midX, y: UIScreen.main.bounds.midY)
+        
+//        view.setNeedsLayout()
+//        view.layoutIfNeeded()
     }
     
     /// Contain the passed view controller to resize it and modify its traits

--- a/Sizes/Classes/ViewControllers/SizesViewController.swift
+++ b/Sizes/Classes/ViewControllers/SizesViewController.swift
@@ -29,6 +29,14 @@ open class SizesViewController: UIViewController {
     /// Scales the contained view when the device to layout is larger than the device than is currently running Sizes
     public var scalesViewIfNecessary: Bool = true
     
+    open override var shouldAutorotate: Bool {
+        return true
+    }
+    
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.all
+    }
+    
     /// Performs layout for selected device, orientation and content size.
     ///
     /// - Parameters:


### PR DESCRIPTION
This PR adds support for resizing the `SizesWindow` to avoid unexpected behavior in multiple occasions like when presenting a modal view controller. It still has a few issues like arranging the configuration view when rotating but I believe this is the way to go. 

![img_2201 trim](https://user-images.githubusercontent.com/14804033/47159161-9a101100-d2c3-11e8-8109-c4224982b496.gif)


Fixes #16. 