### PR TITLE
Fix width of configuration window

### DIFF
--- a/Sizes/Classes/UI/SizesWindow.swift
+++ b/Sizes/Classes/UI/SizesWindow.swift
@@ -37,7 +37,7 @@ open class SizesWindow: UIWindow {
         let configurationController = ConfigurationViewController()
         let screenBounds = UIScreen.main.bounds
         let configurationViewHeight = configurationController.view.bounds.height
-        configurationWindow = UIWindow(frame: CGRect(x: 0, y: screenBounds.height, width: 375, height: configurationViewHeight))
+        configurationWindow = UIWindow(frame: CGRect(x: 0, y: screenBounds.height, width: screenBounds.width, height: configurationViewHeight))
         configurationWindow.backgroundColor = .clear
         configurationWindow.windowLevel = .alert
         configurationWindow.rootViewController = configurationController


### PR DESCRIPTION
I noticed that the width of the config window is set to 375 which looks fine on iPhone SE but doesn't look right on larger devices such as iPhone 8 etc. So this commit fixes that.
