### PR TITLE
Fix for Xcode's New Build System + CocoaPods

### DIFF
--- a/Sizes.podspec
+++ b/Sizes.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
 
-  s.source_files = 'Sizes/Classes/**/*'
+  s.source_files = 'Sizes/Classes/**/*.{h,m,swift}'
+  s.resources = ['Sizes/Classes/ViewControllers/ConfigurationViewController.xib']
   s.swift_version = '4.2'
 end


### PR DESCRIPTION
Fixes Cocoapods compatibility with Xcode 9/10's 'New' build system.

Previously reported (https://github.com/marcosgriselli/Sizes/issues/25), errors previously thrown would appear similar to:

 ```error: invalid task ('StripNIB /Users/.../Library/Developer/Xcode/DerivedData/.../Build/Products/Debug-iphonesimulator/Sizes/ConfigurationViewController.nib') with mutable output but no other virtual output node (in target 'Sizes')```